### PR TITLE
Add XDC Network BullaInstantPayment address

### DIFF
--- a/bulla_registry_export/address_config.json
+++ b/bulla_registry_export/address_config.json
@@ -90,6 +90,9 @@
       "batchCreate": "0x1c534661326b41c8b8aab5631ECED6D9755ff192",
       "bullaInstantPayment": "0xFcA0E74af938919E43541D40330212324C8aF27F"
     },
+    "50": {
+      "bullaInstantPayment": "0xd60F8Fc651BdcEe2C6Ed9914d610c0E22cE190d6"
+    },
     "11155111": {
       "bullaManager": "0x15C43c1483816C0DEfcb3154b09A9e450d139033",
       "bullaClaim": "0x3702D060cbB102b6AebF40B40880F77BeF3d7225",


### PR DESCRIPTION
## Summary
- Adds BullaInstantPayment address for XDC Network (chain ID 50) to the registry export
- Address: 0xd60F8Fc651BdcEe2C6Ed9914d610c0E22cE190d6
- Deployed 2026-04-13. No other V1 contracts were deployed on XDC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)